### PR TITLE
use static array instead of vec! to reduce allocations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,9 +83,8 @@ fn get_shell() -> String {
         .unwrap_or_else(|| "Unknown".into())
 }
 
-
 fn get_pkgs() -> String {
-    let package_managers = vec![
+    let package_managers: &[(&str, &[&str], &str)] = &[
         ("xbps-query", &["-l"][..], "xbps"),
         ("apk", &["info"], "apk"),
         ("rpm", &["-qa"], "rpm"),
@@ -112,7 +111,6 @@ fn get_pkgs() -> String {
                 .and_then(|output| {
                     let count = String::from_utf8_lossy(&output.stdout)
                         .lines()
-                        .filter(|line| !line.is_empty())
                         .count();
                     (count > 0).then(|| format!("{}({})", count, tag))
                 })


### PR DESCRIPTION
This refactor replaces the `vec!` in `get_pkgs` with a static array `&[(&str, &[&str], &str)]`.

## Changes:

- Replaced Vec with a static array to avoid dynamic memory allocation.

## Why?

- The package manager list is static and does not need to be allocated dynamically.